### PR TITLE
fix: Make Vola API call asynchronous to prevent gateway timeout

### DIFF
--- a/src/main/java/school/hei/tsinjo/PojaApplication.java
+++ b/src/main/java/school/hei/tsinjo/PojaApplication.java
@@ -2,10 +2,12 @@ package school.hei.tsinjo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 @PojaGenerated
 public class PojaApplication {
 

--- a/src/main/java/school/hei/tsinjo/service/DonationService.java
+++ b/src/main/java/school/hei/tsinjo/service/DonationService.java
@@ -3,7 +3,6 @@ package school.hei.tsinjo.service;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import school.hei.tsinjo.client.VolaClient;
 import school.hei.tsinjo.endpoint.rest.controller.dto.DonationForm;
 import school.hei.tsinjo.model.Donation;
 import school.hei.tsinjo.model.Donor;
@@ -15,7 +14,7 @@ import school.hei.tsinjo.repository.DonationRepository;
 public class DonationService {
 
   private final DonationRepository donationRepository;
-  private final VolaClient volaClient;
+  private final VolaAsyncService volaAsyncService;
 
   public void createDonation(DonationForm form) {
     Donor donor =
@@ -38,6 +37,6 @@ public class DonationService {
 
     donationRepository.save(donation);
 
-    volaClient.createPayment(donor.getEmail(), payment.getPspPaymentId(), payment.getMethod());
+    volaAsyncService.createPayment(donor.getEmail(), payment.getPspPaymentId(), payment.getMethod());
   }
 }

--- a/src/main/java/school/hei/tsinjo/service/VolaAsyncService.java
+++ b/src/main/java/school/hei/tsinjo/service/VolaAsyncService.java
@@ -1,0 +1,19 @@
+package school.hei.tsinjo.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import school.hei.tsinjo.client.VolaClient;
+import school.hei.tsinjo.model.Payment;
+
+@Service
+@AllArgsConstructor
+public class VolaAsyncService {
+
+  private final VolaClient volaClient;
+
+  @Async
+  public void createPayment(String payerEmail, String pspPaymentId, Payment.PaymentMethod pspType) {
+    volaClient.createPayment(payerEmail, pspPaymentId, pspType);
+  }
+}

--- a/src/test/java/school/hei/tsinjo/service/DonationServiceTest.java
+++ b/src/test/java/school/hei/tsinjo/service/DonationServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import school.hei.tsinjo.client.VolaClient;
 import school.hei.tsinjo.endpoint.rest.controller.dto.DonationForm;
 import school.hei.tsinjo.model.Donation;
 import school.hei.tsinjo.model.Payment;
@@ -19,7 +18,7 @@ class DonationServiceTest {
 
   @Mock private DonationRepository donationRepository;
 
-  @Mock private VolaClient volaClient;
+  @Mock private VolaAsyncService volaAsyncService;
 
   @InjectMocks private DonationService donationService;
 
@@ -48,7 +47,7 @@ class DonationServiceTest {
     assertEquals(10000, savedDonation.getPayment().getAmount());
     assertEquals(Payment.PaymentStatus.VERIFYING, savedDonation.getPayment().getStatus());
 
-    verify(volaClient)
+    verify(volaAsyncService)
         .createPayment("test.donor@example.com", "psp-123", Payment.PaymentMethod.ORANGE_MONEY);
   }
 }


### PR DESCRIPTION
This commit introduces an asynchronous service to handle the creation of payments with the Vola API. This prevents the web request from blocking and timing out if the Vola API is slow to respond.

- Added VolaAsyncService with an @Async method.
- Updated DonationService to use the new async service.
- Enabled @Async in the main application class.
- Updated unit tests to reflect the changes.